### PR TITLE
Basic test working

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 
   :npm {:dependencies [[express "4.15.3"]
                        [cors "2.8.4"]
-                       [express-graphql "0.6.12"]
+                       [express-graphql "0.6.13"]
                        [graphql "0.13.1"]
                        [graphql-tools "3.0.1"]]
         :devDependencies [[ws "2.0.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-server-graphql "1.0.12"
+(defproject district0x/district-server-graphql "1.1.0"
   :description "district0x server module for setting up GraphQL server"
   :url "https://github.com/district0x/district-server-graphql"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,8 @@
   :npm {:dependencies [[express "4.15.3"]
                        [cors "2.8.4"]
                        [express-graphql "0.6.12"]
-                       [graphql "0.13.1"]]
+                       [graphql "0.13.1"]
+                       [graphql-tools "3.0.1"]]
         :devDependencies [[ws "2.0.1"]
                           [xhr2 "0.1.4"]]}
 

--- a/src/district/server/graphql.cljs
+++ b/src/district/server/graphql.cljs
@@ -1,12 +1,13 @@
 (ns district.server.graphql
-  (:require
-    [cljs.core.async :refer [<! chan put!]]
-    [cljs.nodejs :as nodejs]
-    [district.graphql-utils :as graphql-utils]
-    [district.server.config :refer [config]]
-    [district.server.graphql.middleware :refer [build-schema create-graphql-middleware]]
-    [graphql-query.core :refer [graphql-query]]
-    [mount.core :as mount :refer [defstate]]))
+  (:require [camel-snake-kebab.extras :refer [transform-keys]]
+            [cljs.nodejs :as nodejs]
+            [district.graphql-utils :as graphql-utils]
+            [district.server.config :refer [config]]
+            [district.server.graphql.middleware
+             :refer
+             [build-schema create-graphql-middleware]]
+            [graphql-query.core :refer [graphql-query]]
+            [mount.core :as mount :refer [defstate]]))
 
 (declare start)
 (declare stop)
@@ -48,19 +49,49 @@
                 (graphql-query query {:kw->gql-name (or kw->gql-name
                                                         (:kw->gql-name (:opts @graphql)))})
                 query)]
-    (graphql-utils/js->clj-response (gql-sync (:schema @graphql) query (:root-value @graphql))
+    (graphql-utils/js->clj-response (gql-sync (:schema @graphql)
+                                              query
+                                              (:root-value @graphql)
+                                              nil nil nil
+                                              (:field-resolver @graphql))
                                     {:gql-name->kw (or gql-name->kw
                                                        (:gql-name->kw (:opts @graphql)))})))
 
+(defn- build-resolvers
+  "Given a map like {:Type {:field1 resolver-fn}} and
+  a kw->gql-name, build a resolvers map as required by graphql-tools."
+  [resolvers-map kw->gql-name]
+  (clj->js
+   (reduce-kv (fn [r type-name fields-map]
+                (assoc r (kw->gql-name type-name) 
+                       (reduce-kv
+                        (fn [fm field-name field-fn]
+                          (assoc fm (kw->gql-name field-name)
+                                 (fn [o args ctx info]
+                                   (field-fn o
+                                             (transform-keys kw->gql-name args)
+                                             ctx
+                                             info))))
+                        {}
+                        fields-map)))
+              {}
+              resolvers-map)))
 
-(defn start [{:keys [:port :middlewares :path :kw->gql-name :gql-name->kw] :as opts}]
+(defn default-field-resolver
+  "Default resolver that tries to return a keyword property
+  given a gql-name, assuming obj is a map"
+  [gql-name->kw obj _ _ info]
+  (when (map? obj)
+   (get obj (gql-name->kw (.-fieldName info)))))
+
+(defn start [{:keys [:port :middlewares :path :kw->gql-name :gql-name->kw :resolvers :field-resolver] :as opts}]
   (let [app (express)
         middlewares (flatten middlewares)
         kw->gql-name (or kw->gql-name graphql-utils/kw->gql-name)
         gql-name->kw (or gql-name->kw graphql-utils/gql-name->kw)
         opts (cond-> opts
                true
-               (update :schema build-schema)
+               (update :schema (partial build-schema (build-resolvers resolvers kw->gql-name)))      
 
                (map? (:root-value opts))
                (update :root-value #(graphql-utils/clj->js-root-value % {:kw->gql-name kw->gql-name
@@ -75,5 +106,7 @@
      :server (.listen app port)
      :schema (:schema opts)
      :root-value (:root-value opts)
+     :resolvers resolvers
+     :field-resolver (or field-resolver (partial default-field-resolver gql-name->kw))
      :opts opts}))
 

--- a/src/district/server/graphql.cljs
+++ b/src/district/server/graphql.cljs
@@ -60,7 +60,7 @@
 (defn- build-resolvers
   "Given a map like {:Type {:field1 resolver-fn}} and
   a kw->gql-name, build a resolvers map as required by graphql-tools."
-  [resolvers-map kw->gql-name]
+  [resolvers-map kw->gql-name gql-name->kw]
   (clj->js
    (reduce-kv (fn [r type-name fields-map]
                 (assoc r (kw->gql-name type-name) 
@@ -69,7 +69,7 @@
                           (assoc fm (kw->gql-name field-name)
                                  (fn [o args ctx info]
                                    (field-fn o
-                                             (transform-keys kw->gql-name args)
+                                             (transform-keys gql-name->kw (js->clj args))
                                              ctx
                                              info))))
                         {}
@@ -92,7 +92,7 @@
         gql-name->kw (or gql-name->kw graphql-utils/gql-name->kw)
         opts (cond-> opts
                true
-               (update :schema (partial build-schema (build-resolvers resolvers kw->gql-name)))      
+               (update :schema (partial build-schema (build-resolvers resolvers kw->gql-name gql-name->kw)))      
 
                (map? (:root-value opts))
                (update :root-value #(graphql-utils/clj->js-root-value % {:kw->gql-name kw->gql-name

--- a/src/district/server/graphql.cljs
+++ b/src/district/server/graphql.cljs
@@ -76,13 +76,14 @@
                         fields-map)))
               {}
               resolvers-map)))
-
-(defn default-field-resolver
+ 
+(defn build-default-field-resolver
   "Default resolver that tries to return a keyword property
   given a gql-name, assuming obj is a map"
-  [gql-name->kw obj _ _ info]
-  (when (map? obj)
-   (get obj (gql-name->kw (.-fieldName info)))))
+  [gql-name->kw]
+  (fn [obj _ _ info]
+    (when (map? obj)
+     (get obj (gql-name->kw (.-fieldName info))))))
 
 (defn start [{:keys [:port :middlewares :path :kw->gql-name :gql-name->kw :resolvers :field-resolver] :as opts}]
   (let [app (express)
@@ -107,6 +108,6 @@
      :schema (:schema opts)
      :root-value (:root-value opts)
      :resolvers resolvers
-     :field-resolver (or field-resolver (partial default-field-resolver gql-name->kw))
+     :field-resolver field-resolver
      :opts opts}))
 

--- a/src/district/server/graphql/middleware.cljs
+++ b/src/district/server/graphql/middleware.cljs
@@ -4,20 +4,20 @@
     [cljs.nodejs :as nodejs]
     [district.graphql-utils :as graphql-utils]))
 
-(def GraphQL (nodejs/require "graphql"))
+;; (def GraphQL (nodejs/require "graphql"))
 (def graphqlHTTP (nodejs/require "express-graphql"))
-(def gql-build-schema (aget GraphQL "buildSchema"))
+;; (def gql-build-schema (aget GraphQL "buildSchema"))
+(def make-executable-schema (aget (nodejs/require "graphql-tools") "makeExecutableSchema"))
 
-(defn build-schema [schema]
-  (cond-> schema
-    (string? schema) gql-build-schema
-    true graphql-utils/add-keyword-type
-    true graphql-utils/add-date-type))
+(defn build-schema [resolvers schema]
+  (-> (make-executable-schema (js-obj "typeDefs" schema
+                                      "resolvers" resolvers))
+      graphql-utils/add-keyword-type
+      graphql-utils/add-date-type))
 
 (defn create-graphql-middleware [opts]
   (-> opts
-    (update :schema build-schema)
-    (->> (map (fn [[k v]] [(cs/->camelCaseString k) v])))
-    (->> (into {}))
-    clj->js
-    graphqlHTTP))
+      (->> (map (fn [[k v]] [(cs/->camelCaseString k) v])))
+      (->> (into {}))
+      clj->js
+      graphqlHTTP))

--- a/test/tests/all.cljs
+++ b/test/tests/all.cljs
@@ -1,12 +1,13 @@
 (ns tests.all
-  (:require
-    [cljs-http.client :as client]
-    [cljs.core.async :refer [<!]]
-    [cljs.nodejs :as nodejs]
-    [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-    [district.server.graphql :refer [run-query]]
-    [mount.core :as mount])
-  (:require-macros [cljs.core.async.macros :refer [go]]))
+  (:require [cljs.nodejs :as nodejs]
+            [cljs.test :refer-macros [deftest use-fixtures is async testing]]
+            [district.graphql-utils :as graphql-utils]
+            [district.server.graphql :refer [run-query]]
+            [graphql-query.core :refer [graphql-query]]
+            [mount.core :as mount]
+            [cljs.core.async :refer [<!]]
+            [cljs-http.client :as client])
+  (:require-macros [cljs.core.async.macros :refer [go]])) 
 
 (set! js/XMLHttpRequest (nodejs/require "xhr2"))
 
@@ -16,36 +17,113 @@
    (fn []
      (mount/stop))})
 
-(deftest tests
-  (async done
-    (let [schema "
+(deftest tests-root-value
+  (let [schema "
           type Query {
             search: [Item]
           }
           type Item {
             title: String
           }"
-          root {:search (constantly [{:title "abc"}])}]
+        root {:search (constantly [{:title "abc"}])}]
 
-      (-> (mount/with-args
-            {:graphql {:port 6333
-                       :path "/graphql"
-                       :schema schema
-                       :root-value root
-                       :graphiql true}})
+    (-> (mount/with-args
+          {:graphql {:port 6333
+                     :path "/graphql"
+                     :schema schema
+                     :resolvers {}
+                     :root-value root
+                     :graphiql true}})
         (mount/start))
 
-      (is (:data (run-query {:queries [[:search [:title]]]}))
-          {:search [{:title "abc"}]})
+    (is (:data (run-query {:queries [[:search [:title]]]}))
+        {:search [{:title "abc"}]})
 
-      (is (:data (run-query "{search {title}}"))
-          {:search [{:title "abc"}]})
+    (is (:data (run-query "{search {title}}"))
+        {:search [{:title "abc"}]})
 
-      (go
-        (is (= (-> (<! (client/post "http://localhost:6333/graphql"
-                                    {:json-params {:query "{search {title}}"}}))
-                 :body
-                 :data)
-               {:search [{:title "abc"}]}))
-        (done)))))
+    (async done
+           (go
+             (is (= (-> (<! (client/post "http://localhost:6333/graphql"
+                                         {:json-params {:query "{search {title}}"}}))
+                        :body
+                        :data)
+                    {:search [{:title "abc"}]}))
+             (done)))))
 
+;; https://github.com/apollographql/graphql-tools/
+(deftest graphql-tools-site-test
+  (let [all-posts (atom [{:id "P1" :title "Post1" :author "A1" :votes 0}
+                         {:id "P2" :title "Post2" :author "A1" :votes 5}
+                         {:id "P3" :title "Post3" :author "A1" :votes 10}])
+        all-authors [{:id "A1" :first-name "FN1" :last-name "LN1" :posts ["P1" "P2" "P3"]}]
+        schema "type Author {
+                         id: ID! 
+                         firstName: String
+                         lastName: String
+                         posts: [Post]
+                       }
+                     
+                       type Post {
+                         id: ID!
+                         title: String
+                         author: Author
+                         votes: Int
+                       }
+                     
+                       type Query {
+                         posts(minVotes: Int): [Post]
+                       }
+                     
+                       type Mutation {
+                         upvotePost (postId: ID!): Post
+                       }
+                     
+                       schema {
+                         query: Query
+                         mutation: Mutation
+                       }"
+        resolvers {:Query {:posts (fn [obj {:keys [min-votes] :as args}]
+                                    (filter #(> (:votes %) min-votes) @all-posts))}
+                   :Mutation {:upvote-post (fn [obj {:keys [post-id] :as args}]
+                                             (.log js/console "Updating !!!!!!!!!!1" post-id)
+                                             (swap! @all-posts
+                                                    #(mapv (fn [p]
+                                                             (if (= (:id p) post-id)
+                                                               (update p :votes inc)
+                                                               p))
+                                                           %)))}
+                   :Author {:posts (fn [{:keys [posts] :as author}]
+                                     (filter (set posts) @all-posts))}
+                   :Post {:author (fn [{:keys [author] :as post}]
+                                    (first (filter #(= (:id %) author) all-authors)))}}]
+
+    (-> (mount/with-args 
+          {:graphql {:port 6333
+                     :path "/graphql"
+                     :schema schema
+                     :resolvers resolvers
+                     :graphiql true}})
+        (mount/start))
+    (let [q1 (graphql-query {:queries [[:posts {:min-votes 4}
+                                        [:id :title :votes [:author [:id :first-name]]]]]}
+                            {:kw->gql-name graphql-utils/kw->gql-name}) 
+          q1-results [{:id "P2" :title "Post2" :author {:id "A1" :first-name "FN1"} :votes 5}
+                      {:id "P3" :title "Post3" :author {:id "A1" :first-name "FN1"} :votes 10}]]
+ 
+      (testing "Query should work if called with run-query"
+        (is (= (get-in (run-query q1) [:data :posts])
+              q1-results)))
+  
+      (testing "Query should work if called from HTTP"
+        (async done
+               (go
+                 (let [post-result (<! (client/post "http://localhost:6333/graphql"
+                                                    {:json-params {:query q1}}))]
+                   (println post-result)
+                   (is (= (-> post-result
+                              :body
+                              :data
+                              :posts)
+                          q1-results)))
+                 (done)))))))


### PR DESCRIPTION
**IMPORTANT Do not merge this until express-graphql "0.6.13" is released it's using an unreleased feature (passing fieldResolver to  graphqlHTTP**

Everything that was previously working should still be working (old tests still passing)
Now graphql component accepts two more keywords :resolvers and :field-resolver
See tests/all.cljs for a usage example.