### PR TITLE
Migration to ApolloServer and context support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,10 @@ jobs:
     working_directory: ~/ci
     docker:
       # Primary container image where all steps run.
-      - image: district0x/cljs-dev
+      - image: 487920318758.dkr.ecr.us-west-2.amazonaws.com/cljs-web3-ci:node-18.7.0
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     steps:
       - checkout
       - restore_cache:
@@ -46,8 +49,10 @@ workflows:
   version: 2
   test_and_deploy:
     jobs:
-      - test
+      - test:
+          context: district0x
       - deploy:
+          context: district0x
           requires:
             - test
           filters:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/district0x/district-server-graphql.svg?style=svg)](https://circleci.com/gh/district0x/district-server-graphql)
 
 Clojurescript-node.js [mount](https://github.com/tolitius/mount) module for a district server, that sets up [GraphQL](http://graphql.org/) server.
-It uses [expressjs](https://expressjs.com/) and [express-graphql](https://github.com/graphql/express-graphql) to set up the server.
+It uses [expressjs](https://expressjs.com/) and [apollo-server](https://www.apollographql.com) to set up the server.
 
 ## Installation
 
@@ -30,7 +30,8 @@ You can pass following args to graphql module:
 See list of [district-server-middlewares](https://github.com/search?q=topic%3Adistrict-server-middleware+org%3Adistrict0x&type=Repositories).
 * `:gql-name->kw` Function for converting GraphQL names into keywords. Default: [gql-name->kw](https://github.com/district0x/district-graphql-utils#gql-name-kw)
 * `:kw->gql-name` Function for converting keywords into GraphQL names. Default: [kw->gql-name](https://github.com/district0x/district-graphql-utils#kw-gql-name)
-* All [GraphQL options](https://github.com/graphql/express-graphql#options) as kebab-cased keywords
+* `:context-fn` Function to use to generate the context of the resolvers from the request 
+* All [ApolloServer options](https://www.apollographql.com/docs/apollo-server/api/apollo-server) as kebab-cased keywords
 
 ```clojure
 (ns my-district
@@ -76,7 +77,7 @@ You can pass query string or [graphql-query](https://github.com/district0x/graph
 This namespace contains function for creating GraphQL expressjs middleware
 
 #### <a name="create-graphql-middleware">`create-graphql-middleware [opts]`
-Creates expressjs graphql middleware. Pass same opt as you'd pass into [GraphQL options](https://github.com/graphql/express-graphql#options).
+Creates expressjs graphql middleware. Pass same opt as you'd pass into [ApolloServer options](https://www.apollographql.com/docs/apollo-server/api/apollo-server).
 For schema you can pass either string or built GraphQL object.
 
 ### <a name="districtservergraphqlutils"> district.server.graphql.utils
@@ -135,5 +136,5 @@ lein repl
 node tests-compiled/run-tests.js
 
 # To run tests without REPL
-lein doo node "tests" once
+lein doo node "nodejs-tests" once
 ```

--- a/project.clj
+++ b/project.clj
@@ -1,21 +1,22 @@
-(defproject district0x/district-server-graphql "1.0.18-SNAPSHOT"
+(defproject district0x/district-server-graphql "1.0.19-SNAPSHOT"
   :description "district0x server module for setting up GraphQL server"
   :url "https://github.com/district0x/district-server-graphql"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[camel-snake-kebab "0.4.0"]
-                 [district0x/district-graphql-utils "1.0.9"]
+                 [district0x/async-helpers "0.1.3"]
+                 [district0x/district-graphql-utils "1.0.11"]
                  [district0x/district-server-config "1.0.1"]
                  [district0x/graphql-query "1.0.6"]
                  [mount "0.1.16"]
                  [org.clojure/clojurescript "1.10.520"]]
 
-  :npm {:dependencies [[express "4.15.3"]
+  :npm {:dependencies [[express "4.18.2"]
                        [cors "2.8.4"]
-                       [express-graphql "0.6.12"]
-                       [graphql-tools "3.0.1"]
-                       [graphql "0.13.1"]]
+                       [graphql "16.6.0"]
+                       ["@graphql-tools/schema" "9.0.13"]
+                       ["@apollo/server" "4.3.0"]]
         :devDependencies [[ws "2.0.1"]
                           [xhr2 "0.1.4"]]}
 

--- a/src/district/server/graphql/middleware.cljs
+++ b/src/district/server/graphql/middleware.cljs
@@ -5,7 +5,8 @@
     [district.graphql-utils :as graphql-utils]))
 
 (def GraphQL (nodejs/require "graphql"))
-(def graphqlHTTP (nodejs/require "express-graphql"))
+(def ApolloServer (aget (nodejs/require "@apollo/server") "ApolloServer"))
+(def express-middleware (aget (nodejs/require "@apollo/server/express4") "expressMiddleware"))
 (def gql-build-schema (aget GraphQL "buildSchema"))
 
 (defn build-schema [schema]
@@ -14,10 +15,14 @@
     true graphql-utils/add-keyword-type
     true graphql-utils/add-date-type))
 
-(defn create-graphql-middleware [opts]
-  (-> opts
-    (update :schema build-schema)
-    (->> (map (fn [[k v]] [(cs/->camelCaseString k) v])))
-    (->> (into {}))
-    clj->js
-    graphqlHTTP))
+(defn create-graphql-middleware [app path opts context-fn]
+  (let [opts (-> opts
+                 (update :schema build-schema)
+                 (->> (map (fn [[k v]] [(cs/->camelCaseString k) v])))
+                 (->> (into {}))
+                 clj->js)
+        server (new ApolloServer opts)]
+    (.then (.start server)
+           (fn []
+             (let [middleware (express-middleware server (when (fn? context-fn) (clj->js {:context context-fn})))]
+               (.use app path middleware))))))


### PR DESCRIPTION
With the current state of the lib, it is not possible to specify a function to create the context to pass based to the resolvers from the request. For example, for passing authentication information. Besides, the middleware library this project is using to enable graphql in the express server (express-graphql) is deprecated and no longer maintained.

This PR adds support for specifying the context function and replaces express-graphql middleware for ApolloServer v4, also enabling support for graphql v16.

Additionally, it properly converts the input to clj structures when receiving mutations queries.